### PR TITLE
Fix timezone in price chart tooltip

### DIFF
--- a/ProTrader-UI/src/pages/Prices.tsx
+++ b/ProTrader-UI/src/pages/Prices.tsx
@@ -205,7 +205,8 @@ export default function Prices() {
         min: startMs,
         max: endMs,
         ticks: {
-          callback: (value: number) => new Date(value).toLocaleString(),
+          callback: (value: number) =>
+            new Date(value).toLocaleString("fr-FR", { timeZone: "UTC" }),
         },
       },
       y: {
@@ -219,7 +220,9 @@ export default function Prices() {
       tooltip: {
         callbacks: {
           title: (items: TooltipItem<"line">[]) =>
-            new Date(items[0].parsed.x as number).toLocaleString(),
+            new Date(items[0].parsed.x as number).toLocaleString("fr-FR", {
+              timeZone: "UTC",
+            }),
         },
       },
     },


### PR DESCRIPTION
## Summary
- Display x-axis ticks and tooltips in UTC for accurate timestamps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c188794a4c8331862ff645f2cce971