### PR TITLE
Fix timezone in price chart tooltip

### DIFF
--- a/ProTrader-UI/src/api.ts
+++ b/ProTrader-UI/src/api.ts
@@ -221,7 +221,7 @@ export async function getHdvTimeseries(
   slugs: string[],
   qty?: string,
   bucket = "day",
-  agg = "avg",
+  agg: string | null = "avg",
   start?: string,
   end?: string,
 ): Promise<TimeseriesSeries[]> {

--- a/ProTrader-UI/src/pages/Prices.tsx
+++ b/ProTrader-UI/src/pages/Prices.tsx
@@ -76,7 +76,14 @@ export default function Prices() {
     }
     (async () => {
       try {
-        const ts = await getHdvTimeseries(selected, qty, "day", "avg", start || undefined, end || undefined);
+        const ts = await getHdvTimeseries(
+          selected,
+          qty,
+          "raw",
+          null,
+          start || undefined,
+          end || undefined,
+        );
         setSeries(ts);
       } catch (e) {
         console.error("Failed to load timeseries", e);
@@ -205,7 +212,8 @@ export default function Prices() {
         min: startMs,
         max: endMs,
         ticks: {
-          callback: (value: number) => new Date(value).toLocaleString(),
+          callback: (value: number) =>
+            new Date(value).toLocaleString("fr-FR", { timeZone: "UTC" }),
         },
       },
       y: {
@@ -219,7 +227,9 @@ export default function Prices() {
       tooltip: {
         callbacks: {
           title: (items: TooltipItem<"line">[]) =>
-            new Date(items[0].parsed.x as number).toLocaleString(),
+            new Date(items[0].parsed.x as number).toLocaleString("fr-FR", {
+              timeZone: "UTC",
+            }),
         },
       },
     },


### PR DESCRIPTION
## Summary
- Fetch raw HDV timeseries data so tooltips show precise timestamps
- Allow `getHdvTimeseries` to omit aggregation parameter

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c188794a4c8331862ff645f2cce971