### PR TITLE
feat(ui): show deviation from average and median

### DIFF
--- a/ProTrader-UI/src/pages/Prices.tsx
+++ b/ProTrader-UI/src/pages/Prices.tsx
@@ -230,6 +230,31 @@ export default function Prices() {
             new Date(items[0].parsed.x as number).toLocaleString("fr-FR", {
               timeZone: "UTC",
             }),
+          label: (item: TooltipItem<"line">) => {
+            const label = item.dataset.label || "";
+            const value = item.parsed.y as number;
+            if (label.includes("moyenne") || label.includes("médiane")) {
+              return `${label}: ${formatPrice(value)} K`;
+            }
+            const parts: string[] = [`${label}: ${formatPrice(value)} K`];
+            const avg = showAvg ? avgValues[label] : null;
+            const med = showMedian ? medianValues[label] : null;
+            if (avg != null) {
+              const diff = value - avg;
+              const diffPerc = (diff / avg) * 100;
+              parts.push(
+                `Δ moy ${diff >= 0 ? "+" : ""}${formatPrice(diff)} K (${diffPerc >= 0 ? "+" : ""}${diffPerc.toFixed(1)}%)`,
+              );
+            }
+            if (med != null) {
+              const diff = value - med;
+              const diffPerc = (diff / med) * 100;
+              parts.push(
+                `Δ méd ${diff >= 0 ? "+" : ""}${formatPrice(diff)} K (${diffPerc >= 0 ? "+" : ""}${diffPerc.toFixed(1)}%)`,
+              );
+            }
+            return parts.join(" | ");
+          },
         },
       },
     },


### PR DESCRIPTION
## Summary
- show price differences from average and median in tooltips, with K and percentage formatting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm ci` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c18c488180833196b4c71c08bc5b6d