### PR TITLE
feat(ui): apply carbon-like design with tailwind

### DIFF
--- a/ProTrader-UI/index.html
+++ b/ProTrader-UI/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <title>ProTrader</title>
   </head>
   <body>

--- a/ProTrader-UI/src/components/Card.tsx
+++ b/ProTrader-UI/src/components/Card.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 export default function Card({ children, className = "" }: Props) {
   return (
-    <section className={`bg-white/80 backdrop-blur rounded-xl shadow-sm ring-1 ring-slate-200 p-4 ${className}`}>
+    <section className={`bg-cds-layer rounded-lg shadow-sm border border-cds-border p-4 ${className}`}>
       {children}
     </section>
   );

--- a/ProTrader-UI/src/components/ResourcePicker.tsx
+++ b/ProTrader-UI/src/components/ResourcePicker.tsx
@@ -154,14 +154,14 @@ export default function ResourcePicker({
         <div className="flex items-center gap-2">
           <button
             onClick={handleReload}
-            className="text-sm px-3 py-2 rounded-xl border border-gray-300 hover:bg-gray-50"
+            className="btn btn-secondary"
             title="Recharger la sélection sauvegardée"
           >
             Recharger
           </button>
           <button
             onClick={handleSave}
-            className="text-sm px-3 py-2 rounded-xl border border-gray-300 hover:bg-gray-50"
+            className="btn btn-primary"
             title="Sauvegarder la sélection actuelle"
           >
             Sauvegarder
@@ -175,11 +175,7 @@ export default function ResourcePicker({
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder={placeholder}
-            className={cx(
-              "w-full rounded-2xl border px-4 py-2 outline-none",
-              "border-gray-300 focus:border-gray-400",
-              "shadow-sm"
-            )}
+            className={cx("input w-full")}
           />
           {loading && (
             <div className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-500">
@@ -190,7 +186,7 @@ export default function ResourcePicker({
         {!!query && (
           <button
             onClick={() => setQuery("")}
-            className="text-sm px-3 py-2 rounded-xl border border-gray-300 hover:bg-gray-50"
+            className="btn btn-secondary"
           >
             Effacer
           </button>
@@ -212,7 +208,9 @@ export default function ResourcePicker({
                 onClick={() => toggleSelect(it)}
                 className={cx(
                   "group w-full text-left rounded-2xl border p-3 transition hover:shadow-sm",
-                  isSelected ? "border-blue-500 ring-2 ring-blue-200" : "border-gray-200"
+                  isSelected
+                    ? "border-cds-interactive ring-2 ring-cds-interactive ring-opacity-50"
+                    : "border-cds-border"
                 )}
               >
                 <div className="flex items-center gap-3">
@@ -254,7 +252,7 @@ export default function ResourcePicker({
         ) : (
           <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {selected.map((it) => (
-              <li key={`sel-${it.id}`} className="rounded-2xl border border-gray-200 p-3">
+              <li key={`sel-${it.id}`} className="rounded-2xl border border-cds-border p-3">
                 <div className="flex items-center gap-3">
                   <div className="w-12 h-12 rounded-xl overflow-hidden bg-gray-100 flex items-center justify-center">
                     {it.img_blob ? (
@@ -270,7 +268,7 @@ export default function ResourcePicker({
                   </div>
                   <button
                     onClick={() => removeSelected(it.id)}
-                    className="ml-auto text-xs px-2 py-1 border rounded-lg hover:bg-gray-50"
+                    className="ml-auto btn btn-secondary text-xs px-2 py-1"
                     title="Retirer"
                   >
                     Retirer

--- a/ProTrader-UI/src/index.css
+++ b/ProTrader-UI/src/index.css
@@ -1,34 +1,30 @@
 @import "tailwindcss";
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap");
 
 /* ---------- Base ---------- */
 @layer base {
   html, body, #root { height: 100%; }
-  body { @apply bg-gray-50 text-gray-900 antialiased; }
+  body { @apply bg-cds-background text-cds-text antialiased font-sans; }
 }
 
 /* ---------- Composants ---------- */
 @layer components {
   /* Cartes / panneaux */
-  .card { @apply bg-white/80 backdrop-blur rounded-xl shadow-sm ring-1 ring-slate-200; }
-  .card-section { @apply border border-gray-200 rounded-lg p-3 bg-white shadow-sm; }
+  .card { @apply bg-cds-layer rounded-lg shadow-sm border border-cds-border; }
+  .card-section { @apply border border-cds-border rounded-lg p-3 bg-cds-layer shadow-sm; }
   .toolbar { @apply flex items-center gap-2; }
 
   /* Boutons */
-  .btn { @apply inline-flex items-center justify-center px-3 py-1.5 rounded-md border text-sm bg-white hover:bg-gray-50
-                 transition-colors disabled:opacity-50 disabled:pointer-events-none; }
-  .btn-primary   { @apply border-blue-600   text-blue-700   hover:bg-blue-50; }
-  .btn-secondary { @apply border-gray-300   text-gray-800   hover:bg-gray-50; }
-  .btn-accent    { @apply border-emerald-600 text-emerald-700 hover:bg-emerald-50; }
-  .btn-danger    { @apply border-red-600    text-red-700    hover:bg-red-50; }
-  .btn-outline   { @apply border-gray-300   text-gray-700   hover:bg-gray-50; }
+  .btn { @apply inline-flex items-center justify-center px-3 py-1.5 rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none; }
+  .btn-primary   { @apply bg-cds-interactive text-white hover:bg-cds-interactive-hover focus:ring-cds-interactive; }
+  .btn-secondary { @apply bg-cds-layer border border-cds-border text-cds-text hover:bg-cds-layer-hover focus:ring-cds-border; }
 
   /* Inputs */
-  .input { @apply border border-gray-300 rounded-md px-2 py-1 bg-white
-                  outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent; }
+  .input { @apply border border-cds-border rounded-md px-3 py-2 bg-cds-layer outline-none focus:ring-2 focus:ring-cds-interactive; }
 
   /* Tabs légers */
-  .tab { @apply px-3 py-1 rounded-md border bg-white hover:bg-gray-50; }
-  .tab-active { @apply bg-gray-100 text-gray-800; }
+  .tab { @apply px-3 py-1 rounded-md border border-cds-border bg-cds-layer hover:bg-cds-layer-hover; }
+  .tab-active { @apply bg-cds-layer-hover text-cds-text; }
 
   /* Petits chips d’état */
   .chip { @apply inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-medium border; }

--- a/ProTrader-UI/src/pages/Home.tsx
+++ b/ProTrader-UI/src/pages/Home.tsx
@@ -111,7 +111,7 @@ export default function Home() {
           <button
             onClick={onStartScript}
             disabled={busy || !agentConnected || selected.length === 0}
-            className="px-4 py-2 rounded-md border border-blue-600 text-blue-700 hover:bg-blue-50 disabled:opacity-50"
+            className="btn btn-primary px-4 py-2"
             title={
               selected.length === 0
                 ? "Sélection vide"

--- a/ProTrader-UI/tailwind.config.js
+++ b/ProTrader-UI/tailwind.config.js
@@ -5,7 +5,20 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ["'IBM Plex Sans'", "sans-serif"],
+      },
+      colors: {
+        'cds-background': '#f4f4f4',
+        'cds-layer': '#ffffff',
+        'cds-layer-hover': '#f4f4f4',
+        'cds-border': '#e0e0e0',
+        'cds-text': '#161616',
+        'cds-interactive': '#0f62fe',
+        'cds-interactive-hover': '#0043ce',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- introduce Carbon-like color tokens and IBM Plex Sans to Tailwind
- style base components and buttons with new Carbon-inspired classes
- update Card, ResourcePicker, and Home page to use Carbon-themed styles

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e1fc08748331b83e2345d25ba770