### PR TITLE
feat(ui): add fortune page with kamas chart

### DIFF
--- a/ProTrader-UI/src/App.tsx
+++ b/ProTrader-UI/src/App.tsx
@@ -5,6 +5,7 @@ import Home from "./pages/Home";
 import PricePoints from "./pages/PricePoints";
 import About from "./pages/About";
 import Prices from "./pages/Prices";
+import Fortune from "./pages/Fortune";
 
 export default function App() {
   const [sidebarOpen, setSidebarOpen] = useState(true);
@@ -12,6 +13,7 @@ export default function App() {
   const titles: Record<string, string> = {
     "/": "Accueil",
     "/prices": "Historique des prix",
+    "/fortune": "Fortune",
     "/config": "Éditeur de configuration",
     "/logs": "Gestion des prix",
     "/about": "À propos",
@@ -82,6 +84,20 @@ export default function App() {
                 <span className="truncate">Prix</span>
               </NavLink>
               <NavLink
+                to="/fortune"
+                className={({ isActive }: { isActive: boolean }) =>
+                  [
+                    "flex items-center gap-2 px-3 py-2 rounded-lg border text-sm",
+                    isActive
+                      ? "bg-sky-50 border-sky-200 text-sky-800"
+                      : "bg-white border-slate-200 hover:bg-slate-50",
+                  ].join(" ")
+                }
+              >
+                <span className="shrink-0">💰</span>
+                <span className="truncate">Fortune</span>
+              </NavLink>
+              <NavLink
                 to="/config"
                 className={({ isActive }: { isActive: boolean }) =>
                   [
@@ -132,6 +148,7 @@ export default function App() {
           <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/prices" element={<Prices />} />
+            <Route path="/fortune" element={<Fortune />} />
             <Route path="/config" element={<ConfigEditor />} />
             <Route path="/logs" element={<PricePoints />} />
             <Route path="/about" element={<About />} />

--- a/ProTrader-UI/src/api.ts
+++ b/ProTrader-UI/src/api.ts
@@ -188,6 +188,23 @@ export async function saveAutoMode(auto: boolean): Promise<{ ok: boolean }> {
   return data as { ok: boolean };
 }
 
+// KAMAS -------------------------------------------------------------------
+
+export type KamasPoint = { t: string; amount: number };
+
+export async function getKamasHistory(
+  bucket = "day",
+  start?: string,
+  end?: string,
+): Promise<KamasPoint[]> {
+  const url = new URL("/api/kamas_history", API_BASE);
+  if (bucket) url.searchParams.set("bucket", bucket);
+  if (start) url.searchParams.set("start", new Date(start).toISOString());
+  if (end) url.searchParams.set("end", new Date(end).toISOString());
+  const data = await fetchJSON(url.toString());
+  return (data?.points ?? []) as KamasPoint[];
+}
+
 // PRICES -------------------------------------------------------------------
 
 export type HdvResource = {

--- a/ProTrader-UI/src/pages/Fortune.tsx
+++ b/ProTrader-UI/src/pages/Fortune.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+import { Chart as ChartJS, LinearScale, PointElement, LineElement, Tooltip, Legend } from "chart.js";
+import { Line } from "react-chartjs-2";
+import { getKamasHistory, type KamasPoint } from "../api";
+
+ChartJS.register(LinearScale, PointElement, LineElement, Tooltip, Legend);
+
+const parseTimestamp = (t: string): number => {
+  const n = Number(t);
+  if (!Number.isNaN(n)) {
+    return n < 1e12 ? n * 1000 : n;
+  }
+  return Date.parse(t.endsWith("Z") ? t : `${t}Z`);
+};
+
+export default function Fortune() {
+  const [points, setPoints] = useState<KamasPoint[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const pts = await getKamasHistory("day");
+        setPoints(pts);
+      } catch (e) {
+        console.error("Failed to load kamas history", e);
+      }
+    })();
+  }, []);
+
+  const data = {
+    datasets: [
+      {
+        label: "Kamas",
+        data: points.map((p) => ({ x: parseTimestamp(p.t), y: p.amount })),
+        borderColor: "#f59e0b",
+        backgroundColor: "#f59e0b",
+        tension: 0.1,
+      },
+    ],
+  };
+
+  const options = {
+    parsing: false,
+    responsive: true,
+    scales: {
+      x: {
+        type: "linear" as const,
+        ticks: {
+          callback: (value: number) =>
+            new Date(value).toLocaleString("fr-FR", { timeZone: "UTC" }),
+        },
+      },
+      y: {
+        type: "linear" as const,
+        beginAtZero: true,
+      },
+    },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          title: (items: any[]) =>
+            new Date(items[0].parsed.x as number).toLocaleString("fr-FR", { timeZone: "UTC" }),
+          label: (item: any) => `${item.parsed.y as number} K`,
+        },
+      },
+    },
+  };
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-lg font-semibold">Fortune</h2>
+      <Line data={data} options={options} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add backend endpoint returning stored kamas history
- expose `getKamasHistory` in UI API
- create Fortune page with line chart and navigation entry

## Testing
- `python -m py_compile ProTrader-Server/app.py`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react/jsx-runtime')*


------
https://chatgpt.com/codex/tasks/task_e_68c7cd33e3b88331a820fe82fdec5e31