### PR TITLE
Affiche les prix médians des ressources dans Fortune

### DIFF
--- a/ProTrader-UI/src/pages/Fortune.tsx
+++ b/ProTrader-UI/src/pages/Fortune.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useState } from "react";
 import { Chart as ChartJS, LinearScale, PointElement, LineElement, Tooltip, Legend } from "chart.js";
 import { Line } from "react-chartjs-2";
-import { getKamasHistory, type KamasPoint } from "../api";
+import {
+  getKamasHistory,
+  loadSelection,
+  getHdvPriceStat,
+  type Item,
+  type KamasPoint,
+} from "../api";
 
 ChartJS.register(LinearScale, PointElement, LineElement, Tooltip, Legend);
 
@@ -13,8 +19,12 @@ const parseTimestamp = (t: string): number => {
   return Date.parse(t.endsWith("Z") ? t : `${t}Z`);
 };
 
+const QTY_LIST = ["x1", "x10", "x100", "x1000"] as const;
+
 export default function Fortune() {
   const [points, setPoints] = useState<KamasPoint[]>([]);
+  const [items, setItems] = useState<Item[]>([]);
+  const [medianMap, setMedianMap] = useState<Record<string, Record<string, number | null>>>({});
 
   useEffect(() => {
     (async () => {
@@ -26,6 +36,51 @@ export default function Fortune() {
       }
     })();
   }, []);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const sel = await loadSelection();
+        setItems(sel);
+      } catch (e) {
+        console.error("Failed to load selection", e);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (items.length === 0) {
+      setMedianMap({});
+      return;
+    }
+    (async () => {
+      const start = new Date(Date.now() - 7 * 24 * 3600 * 1000).toISOString();
+      const end = new Date().toISOString();
+      const map: Record<string, Record<string, number | null>> = {};
+      for (const it of items) {
+        const qmap: Record<string, number | null> = {};
+        await Promise.all(
+          QTY_LIST.map(async (qty) => {
+            try {
+              const stat = await getHdvPriceStat(it.slug_fr, qty, "median", start, end);
+              qmap[qty] = stat.value ?? null;
+            } catch {
+              qmap[qty] = null;
+            }
+          })
+        );
+        map[it.slug_fr] = qmap;
+      }
+      setMedianMap(map);
+    })();
+  }, [items]);
+
+  const imgSrc = (it: Item) => {
+    if (!it.img_blob) return "";
+    const maybePng = it.img_blob.startsWith("iVBOR");
+    const mime = maybePng ? "image/png" : "image/jpeg";
+    return `data:${mime};base64,${it.img_blob}`;
+  };
 
   const data = {
     datasets: [
@@ -71,6 +126,49 @@ export default function Fortune() {
     <div className="space-y-6">
       <h2 className="text-lg font-semibold">Fortune</h2>
       <Line data={data} options={options} />
+      {items.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm border-collapse">
+            <thead>
+              <tr className="border-b text-left">
+                <th className="p-2">Ressource</th>
+                <th className="p-2">Quantité</th>
+                <th className="p-2">Prix médian (K)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.flatMap((it) =>
+                QTY_LIST.map((qty) => (
+                  <tr key={`${it.id}-${qty}`} className="border-b last:border-0">
+                    <td className="p-2">
+                      <div className="flex items-center gap-2">
+                        {it.img_blob ? (
+                          // eslint-disable-next-line jsx-a11y/alt-text
+                          <img
+                            src={imgSrc(it)}
+                            alt={it.name_fr}
+                            className="w-6 h-6 rounded object-cover"
+                          />
+                        ) : (
+                          <div className="w-6 h-6 bg-gray-200 rounded" />
+                        )}
+                        <span className="truncate">{it.name_fr}</span>
+                      </div>
+                    </td>
+                    <td className="p-2">{qty}</td>
+                    <td className="p-2">
+                      {(() => {
+                        const v = medianMap[it.slug_fr]?.[qty];
+                        return v != null ? `${Math.round(v / 1000)} K` : "—";
+                      })()}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Affiche la liste des ressources sélectionnées sous le graphe de fortune
- Calcule le prix médian des 7 derniers jours pour chaque quantité

## Testing
- `npm test` *(missing script: test)*
- `npm run lint` *(missing @eslint/js; `npm install` renvoyé 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d20c25488331a3c914f5702a1e6a