### PR TITLE
Compute server-side median prices per quantity

### DIFF
--- a/ProTrader-UI/src/api.ts
+++ b/ProTrader-UI/src/api.ts
@@ -199,8 +199,8 @@ export async function getKamasHistory(
 ): Promise<KamasPoint[]> {
   const url = new URL("/api/kamas_history", API_BASE);
   if (bucket) url.searchParams.set("bucket", bucket);
-  if (start) url.searchParams.set("start", new Date(start).toISOString());
-  if (end) url.searchParams.set("end", new Date(end).toISOString());
+  if (start) url.searchParams.set("date_from", new Date(start).toISOString());
+  if (end) url.searchParams.set("date_to", new Date(end).toISOString());
   const data = await fetchJSON(url.toString());
   return (data?.points ?? []) as KamasPoint[];
 }
@@ -248,8 +248,8 @@ export async function getHdvTimeseries(
   if (qty) url.searchParams.set("qty", qty);
   if (bucket) url.searchParams.set("bucket", bucket);
   if (agg) url.searchParams.set("agg", agg);
-  if (start) url.searchParams.set("start", new Date(start).toISOString());
-  if (end) url.searchParams.set("end", new Date(end).toISOString());
+  if (start) url.searchParams.set("date_from", new Date(start).toISOString());
+  if (end) url.searchParams.set("date_to", new Date(end).toISOString());
   const data = await fetchJSON(url.toString());
   return (data?.series ?? []) as TimeseriesSeries[];
 }

--- a/ProTrader-UI/src/pages/Fortune.tsx
+++ b/ProTrader-UI/src/pages/Fortune.tsx
@@ -4,7 +4,7 @@ import { Line } from "react-chartjs-2";
 import {
   getKamasHistory,
   loadSelection,
-  getHdvTimeseries,
+  getHdvPriceStat,
   type Item,
   type KamasPoint,
 } from "../api";
@@ -20,15 +20,6 @@ const parseTimestamp = (t: string): number => {
 };
 
 const QTY_LIST = ["x1", "x10", "x100", "x1000"] as const;
-
-const median = (values: number[]): number | null => {
-  if (values.length === 0) return null;
-  const sorted = [...values].sort((a, b) => a - b);
-  const mid = Math.floor(sorted.length / 2);
-  return sorted.length % 2 === 0
-    ? (sorted[mid - 1] + sorted[mid]) / 2
-    : sorted[mid];
-};
 
 export default function Fortune() {
   const [points, setPoints] = useState<KamasPoint[]>([]);
@@ -71,16 +62,8 @@ export default function Fortune() {
         await Promise.all(
           QTY_LIST.map(async (qty) => {
             try {
-              const series = await getHdvTimeseries(
-                [it.slug_fr],
-                qty,
-                "raw",
-                null,
-                start,
-                end,
-              );
-              const prices = series[0]?.points.map((p) => p.price ?? p.value ?? 0) ?? [];
-              qmap[qty] = median(prices);
+              const stat = await getHdvPriceStat(it.slug_fr, qty, "median", start, end);
+              qmap[qty] = stat.value;
             } catch {
               qmap[qty] = null;
             }


### PR DESCRIPTION
## Summary
- Fetch median price per quantity via backend API on the Fortune page
- Use correct `date_from`/`date_to` parameters for HDV timeseries requests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm ci` *(fails: 403 Forbidden from registry.npmjs.org)*
- `npm run build` *(fails: TypeScript cannot find React and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c7db6e13d8833185c968bb8244f86d