### PR TITLE
fix: scale median prices by lot size in Fortune UI

### DIFF
--- a/ProTrader-UI/src/api.ts
+++ b/ProTrader-UI/src/api.ts
@@ -265,8 +265,8 @@ export type HdvPriceStat = {
 };
 
 /**
- * Fetch a simple statistic (average or median) of lot prices for a resource.
- * Prices are returned as recorded in kamas for the specified quantity.
+ * Fetch a simple statistic (average or median) of unit prices for a resource
+ * and convert it to a lot price based on the requested quantity.
  */
 export async function getHdvPriceStat(
   slug: string,
@@ -281,8 +281,12 @@ export async function getHdvPriceStat(
   url.searchParams.set("stat", stat);
   if (start) url.searchParams.set("date_from", new Date(start).toISOString());
   if (end) url.searchParams.set("date_to", new Date(end).toISOString());
-  const data = await fetchJSON(url.toString());
-  return data as HdvPriceStat;
+  const data = (await fetchJSON(url.toString())) as HdvPriceStat;
+  const qtyNum = Number(qty.slice(1));
+  return {
+    ...data,
+    value: data.value != null ? data.value * qtyNum : null,
+  };
 }
 
 // --- Raw price points management ------------------------------------------


### PR DESCRIPTION
## Summary
- scale HDV price stats by requested lot quantity

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm install` (fails: 403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_68c7e85ad2f08331afcfd25d9233d7cd