### PR TITLE
Fix median price display in Fortune table

### DIFF
--- a/ProTrader-UI/src/pages/Fortune.tsx
+++ b/ProTrader-UI/src/pages/Fortune.tsx
@@ -83,7 +83,7 @@ export default function Fortune() {
     return `data:${mime};base64,${it.img_blob}`;
   };
 
-  const formatKamas = (v: number) => `${Math.round(v / 1000).toLocaleString("fr-FR")} K`;
+  const formatKamas = (v: number) => `${Math.round(v).toLocaleString("fr-FR")} K`;
 
   const data = {
     datasets: [


### PR DESCRIPTION
## Summary
- show full kamas value in Fortune median table

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f01555048331ae4fbdf7b34a0f4c