### PR TITLE
feat(fortune): add margin controls

### DIFF
--- a/ProTrader-UI/src/api.ts
+++ b/ProTrader-UI/src/api.ts
@@ -133,6 +133,10 @@ export type Item = {
   img_blob: string; // base64 (sans data: prefix)
 };
 
+export type SelectedItem = Item & {
+  settings?: Partial<Record<Qty, { margin_type: "percent" | "absolute"; margin_value: number; active: boolean }>>;
+};
+
 export async function searchItems(query: string, limit = 20): Promise<Item[]> {
   const url = new URL("/api/items", API_BASE);
   if (query) url.searchParams.set("query", query);
@@ -150,10 +154,10 @@ export async function getItemsByIds(ids: number[], limit = 200): Promise<Item[]>
   return (data?.items ?? []) as Item[];
 }
 
-export async function loadSelection(): Promise<Item[]> {
+export async function loadSelection(): Promise<SelectedItem[]> {
   const url = new URL("/api/selection", API_BASE);
   const data = await fetchJSON(url.toString());
-  return (data?.items ?? []) as Item[];
+  return (data?.items ?? []) as SelectedItem[];
 }
 
 export async function saveSelection(ids: number[]): Promise<{ ok: boolean; count: number }> {
@@ -165,6 +169,29 @@ export async function saveSelection(ids: number[]): Promise<{ ok: boolean; count
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ ids }),
     }
+  );
+  return data as { ok: boolean; count: number };
+}
+
+export type SelectionSetting = {
+  item_id: number;
+  qty: Qty;
+  margin_type: "percent" | "absolute";
+  margin_value: number;
+  active: boolean;
+};
+
+export async function saveSelectionSettings(
+  items: SelectionSetting[],
+): Promise<{ ok: boolean; count: number }> {
+  const url = new URL("/api/selection_settings", API_BASE);
+  const data = await fetchJSON(
+    url.toString(),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ items }),
+    },
   );
   return data as { ok: boolean; count: number };
 }


### PR DESCRIPTION
## Summary
- extend selection storage with per-quantity margin settings
- expose selection settings API endpoint
- add margin, value, profit and active columns on Fortune page

## Testing
- `python -m py_compile ProTrader-Server/app.py`
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm install` (fails: 403 Forbidden)
- `npm run build` (fails: missing React/TS deps)


------
https://chatgpt.com/codex/tasks/task_e_68c7f5c4dfbc83319cf238be61f3f94c