### PR TITLE
Grey out inactive rows in fortune table

### DIFF
--- a/ProTrader-UI/src/pages/Fortune.tsx
+++ b/ProTrader-UI/src/pages/Fortune.tsx
@@ -199,8 +199,13 @@ export default function Fortune() {
                   }
                   const profit =
                     median != null && purchase != null ? median - purchase : null;
-                  return (
-                    <tr key={key} className="border-b last:border-0">
+                    return (
+                      <tr
+                        key={key}
+                        className={`border-b last:border-0 ${
+                          cfg.active ? "" : "bg-gray-50 text-gray-500"
+                        }`}
+                      >
                       <td className="p-2">
                         <div className="flex items-center gap-2">
                           {it.img_blob ? (


### PR DESCRIPTION
## Summary
- Slightly grey out inactive rows in the Fortune table for clearer visual separation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68c7fc8f2794833191c95a140d016859