### PR TITLE
Add trade mode toggle with persistence

### DIFF
--- a/ProTrader-Server/app.py
+++ b/ProTrader-Server/app.py
@@ -209,6 +209,31 @@ def save_auto_mode_to_db(auto: bool) -> None:
         conn.close()
 
 
+def load_trade_mode_from_db() -> bool:
+    conn = get_db()
+    try:
+        ensure_settings_schema(conn)
+        cur = conn.cursor()
+        cur.execute("SELECT value FROM settings WHERE key='trade_mode'")
+        row = cur.fetchone()
+        return bool(row and row["value"] == "1")
+    finally:
+        conn.close()
+
+
+def save_trade_mode_to_db(trade: bool) -> None:
+    conn = get_db()
+    try:
+        ensure_settings_schema(conn)
+        conn.execute(
+            "REPLACE INTO settings (key, value) VALUES ('trade_mode', ?)",
+            ("1" if trade else "0",),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def get_selected_slugs() -> List[str]:
     conn = get_db()
     try:
@@ -395,6 +420,18 @@ def get_auto_mode_endpoint():
 def save_auto_mode_endpoint(body: Dict[str, Any] = Body(...)):
     auto = bool(body.get("auto"))
     save_auto_mode_to_db(auto)
+    return {"ok": True}
+
+
+@app.get("/api/trade_mode")
+def get_trade_mode_endpoint():
+    return {"trade": load_trade_mode_from_db()}
+
+
+@app.post("/api/trade_mode")
+def save_trade_mode_endpoint(body: Dict[str, Any] = Body(...)):
+    trade = bool(body.get("trade"))
+    save_trade_mode_to_db(trade)
     return {"ok": True}
 
 

--- a/ProTrader-UI/src/api.ts
+++ b/ProTrader-UI/src/api.ts
@@ -215,6 +215,25 @@ export async function saveAutoMode(auto: boolean): Promise<{ ok: boolean }> {
   return data as { ok: boolean };
 }
 
+export async function loadTradeMode(): Promise<boolean> {
+  const url = new URL("/api/trade_mode", API_BASE);
+  const data = await fetchJSON(url.toString());
+  return !!data?.trade;
+}
+
+export async function saveTradeMode(trade: boolean): Promise<{ ok: boolean }> {
+  const url = new URL("/api/trade_mode", API_BASE);
+  const data = await fetchJSON(
+    url.toString(),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ trade }),
+    }
+  );
+  return data as { ok: boolean };
+}
+
 // KAMAS -------------------------------------------------------------------
 
 export type KamasPoint = { t: string; amount: number };

--- a/ProTrader-UI/src/pages/Home.tsx
+++ b/ProTrader-UI/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { makeUIWebSocket, sendCommand, loadAutoMode, saveAutoMode } from "../api";
+import { makeUIWebSocket, sendCommand, loadAutoMode, saveAutoMode, loadTradeMode, saveTradeMode } from "../api";
 import type { Item } from "../api";
 import ResourcePicker from "../components/ResourcePicker";
 import Card from "../components/Card";
@@ -12,6 +12,7 @@ export default function Home() {
   const [log, setLog] = useState<string[]>([]);
   const [selected, setSelected] = useState<Item[]>([]);
   const [autoMode, setAutoMode] = useState(false);
+  const [tradeMode, setTradeMode] = useState(false);
 
   // WebSocket pour suivre le statut de l’agent
   useEffect(() => {
@@ -29,12 +30,19 @@ export default function Home() {
 
   useEffect(() => {
     loadAutoMode().then((v) => setAutoMode(!!v)).catch(() => {});
+    loadTradeMode().then((v) => setTradeMode(!!v)).catch(() => {});
   }, []);
 
   async function toggleAutoMode() {
     const v = !autoMode;
     setAutoMode(v);
     try { await saveAutoMode(v); } catch {}
+  }
+
+  async function toggleTradeMode() {
+    const v = !tradeMode;
+    setTradeMode(v);
+    try { await saveTradeMode(v); } catch {}
   }
 
   function buildStartArgs(items: Item[]) {
@@ -87,6 +95,15 @@ export default function Home() {
             className="h-4 w-4"
           />
           <span>Mode auto</span>
+        </label>
+        <label className="mt-2 flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={tradeMode}
+            onChange={toggleTradeMode}
+            className="h-4 w-4"
+          />
+          <span>Mode achat/revente</span>
         </label>
       </Card>
 


### PR DESCRIPTION
## Summary
- add backend storage and API endpoints for trade mode
- expose trade mode API helpers in frontend
- add "Mode achat/revente" checkbox on home page

## Testing
- `python -m py_compile app.py`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js'; `npm ci` blocked with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c80a9d87208331a543cefa53ec2144