### PR TITLE
feat: derive active lines from selection settings

### DIFF
--- a/ProTrader-Agent/actions/test.py
+++ b/ProTrader-Agent/actions/test.py
@@ -31,7 +31,14 @@ def _resolve_temp_dir() -> Path:
 @register("start_script")
 def start_script(args: Dict[str, Any], cmd_id: str) -> Dict[str, Any]:
     items = (args or {}).get("items") or []
-    logger.info("start_script called with %d item(s)", len(items))
+    fortune_lines = (args or {}).get("fortune_lines") or []
+    logger.info(
+        "start_script called with %d item(s) and %d fortune line(s)",
+        len(items),
+        len(fortune_lines),
+    )
+    if fortune_lines:
+        logger.info("fortune lines: %s", fortune_lines)
     if not items:
         return {
             "type": "script_result",


### PR DESCRIPTION
## Summary
- build `start_script` fortune lines from `selection_items.settings`
- log provided fortune lines in agent for future trading logic
- only send fortune lines when trade mode checkbox is enabled

## Testing
- `pip install opencv-python Pillow` *(fails: Could not find a version that satisfies the requirement opencv-python; No matching distribution found for opencv-python)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2'; No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68c815cb598c833184000d5da6e8fb79