### PR TITLE
Add optional buy confirmation step in login FSM

### DIFF
--- a/ProTrader-Agent/actions/test.py
+++ b/ProTrader-Agent/actions/test.py
@@ -79,7 +79,7 @@ def start_script(args: Dict[str, Any], cmd_id: str) -> Dict[str, Any]:
 
     # Lance le FSM avec la liste complète des ressources
     logger.info("Launching script thread with %d resource(s)", len(resources))
-    threading.Thread(target=run, args=(resources,), daemon=True).start()
+    threading.Thread(target=run, args=(resources, fortune_lines), daemon=True).start()
 
     return {
         "type": "script_result",

--- a/ProTrader-Agent/config.yaml
+++ b/ProTrader-Agent/config.yaml
@@ -15,6 +15,7 @@ templates:
   qte_x100: qte_x100.png
   qte_x1000: qte_x1000.png
   recherche: recherche.png
+  confirmer_achat: confirmer_achat.png
   kamas: kamas.png
 settings:
   monitor_index: 1


### PR DESCRIPTION
## Summary
- add an optional `CLIC_ACHAT` state that clicks the buy button and waits for the confirmation template when a fortune line exists for the scanned quantity
- pass the received fortune lines to the login FSM and reuse them to trigger purchases without resetting the scan context when returning from the new state
- expose the confirmation template in the agent config so the automation can look for it

## Testing
- pytest *(fails: missing cv2 and Pillow runtime dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9562e80e48331ba7813a8cbc7564e