### PR TITLE
Skip redundant sale quantity selection clicks

### DIFF
--- a/ProTrader-Agent/scripts/login.py
+++ b/ProTrader-Agent/scripts/login.py
@@ -502,9 +502,12 @@ def on_tick_vente_selection_qte(fsm):
             continue
         res = find_template_on_screen(template_path=str(path), debug=True)
         if res:
-            move_click(res.center[0], res.center[1])
             sale["selected_sel_qty"] = candidate
-            time.sleep(0.5)
+            if candidate == qty:
+                time.sleep(1)
+            else:
+                move_click(res.center[0], res.center[1])
+                time.sleep(0.5)
             return "VENTE_CLIQUER_VENTE"
 
     if not use_alternatives:


### PR DESCRIPTION
## Summary
- avoid clicking the sale quantity selector when the desired quantity is already active
- wait briefly before proceeding so the interface can transition to the entry step

## Testing
- python -m compileall ProTrader-Agent/scripts/login.py

------
https://chatgpt.com/codex/tasks/task_e_68ca79dba4788331bfc068d89e853e4c