### PR TITLE
Skip redundant sale button search when quantity already selected

### DIFF
--- a/ProTrader-Agent/scripts/login.py
+++ b/ProTrader-Agent/scripts/login.py
@@ -517,10 +517,15 @@ def on_tick_vente_selection_qte(fsm):
             )
             if candidate == qty:
                 time.sleep(1)
+                sale["selected_sale_qty"] = candidate
+                sale.pop("vente_fallback_click", None)
+                sale.pop("saisie_force_tab", None)
+                sale["vente_attempts"] = 0
+                return "VENTE_SAISIE"
             else:
                 move_click(res.center[0], res.center[1])
                 time.sleep(0.5)
-            return "VENTE_CLIQUER_VENTE"
+                return "VENTE_CLIQUER_VENTE"
 
     if not use_alternatives:
         sale["sel_attempts"] = sale.get("sel_attempts", 0) + 1


### PR DESCRIPTION
## Summary
- allow the sale workflow to bypass the vente button search when the desired sel_vente quantity is already selected
- reset related sale state fields before jumping straight to the price entry step

## Testing
- python -m compileall ProTrader-Agent/scripts/login.py

------
https://chatgpt.com/codex/tasks/task_e_68ca80e43e18833189e56c45296590e5