### PR TITLE
Fix fortune filters to use current datetime range

### DIFF
--- a/ProTrader-UI/src/pages/Fortune.tsx
+++ b/ProTrader-UI/src/pages/Fortune.tsx
@@ -7,6 +7,7 @@ import {
   loadSelection,
   getHdvPriceStat,
   saveSelectionSettings,
+  normalizeDateParam,
   type SelectedItem,
   type KamasPoint,
   type Qty,
@@ -70,8 +71,10 @@ export default function Fortune() {
     const fetchData = async () => {
       const cfg = TIME_RANGES[timeRange];
       const now = new Date();
-      const endIso = now.toISOString();
-      const startIso = cfg.durationMs ? new Date(now.getTime() - cfg.durationMs).toISOString() : undefined;
+      const endIso = normalizeDateParam(now);
+      const startIso = cfg.durationMs
+        ? normalizeDateParam(new Date(now.getTime() - cfg.durationMs))
+        : undefined;
       try {
         const [pts, purchaseList] = await Promise.all([
           getKamasHistory(cfg.bucket, startIso, endIso),
@@ -122,8 +125,8 @@ export default function Fortune() {
       return;
     }
     (async () => {
-      const start = new Date(Date.now() - 7 * 24 * 3600 * 1000).toISOString();
-      const end = new Date().toISOString();
+      const start = normalizeDateParam(new Date(Date.now() - 7 * 24 * 3600 * 1000));
+      const end = normalizeDateParam(new Date());
       const map: Record<string, Record<Qty, number | null>> = {};
       for (const it of items) {
         const qmap: Record<Qty, number | null> = {} as Record<Qty, number | null>;


### PR DESCRIPTION
## Summary
- add a normalizeDateParam helper that strips milliseconds from ISO timestamps before sending them to the backend
- update all date-based API calls and the Fortune page to use the helper so 1d/3d/1w filters rely on the live current time

## Testing
- `npm install` *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/@types%2fjs-yaml)*

------
https://chatgpt.com/codex/tasks/task_e_68d15a948e6483318ade5cebe5e5d22e