### PR TITLE
Fix fortune page time filters

### DIFF
--- a/ProTrader-UI/src/api.ts
+++ b/ProTrader-UI/src/api.ts
@@ -268,8 +268,8 @@ export async function getKamasHistory(
 ): Promise<KamasPoint[]> {
   const url = new URL("/api/kamas_history", API_BASE);
   if (bucket) url.searchParams.set("bucket", bucket);
-  if (start) url.searchParams.set("date_from", normalizeDateParam(start));
-  if (end) url.searchParams.set("date_to", normalizeDateParam(end));
+  if (start) url.searchParams.set("start", normalizeDateParam(start));
+  if (end) url.searchParams.set("end", normalizeDateParam(end));
   const data = await fetchJSON(url.toString());
   return (data?.points ?? []) as KamasPoint[];
 }


### PR DESCRIPTION
## Summary
- align the getKamasHistory query parameters with the backend API so the selected time range is honored

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' because npm install is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d15f1c17e483318cb2ef74317f0b20